### PR TITLE
Include refmap for DrillBlockMixin

### DIFF
--- a/src/main/java/com/cake/drill_drain/mixin/DrillBlockMixin.java
+++ b/src/main/java/com/cake/drill_drain/mixin/DrillBlockMixin.java
@@ -20,7 +20,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-@Mixin(remap = false, value = DrillBlock.class)
+@Mixin(value = DrillBlock.class)
 public class DrillBlockMixin implements DrillBlockMixinAccess {
 
     /**


### PR DESCRIPTION
Fixes startup crash if running mod in a non development environment.