### PR TITLE
Fix PonderPlugin.

### DIFF
--- a/src/main/java/com/cake/drill_drain/foundation/DDPonderPlugin.java
+++ b/src/main/java/com/cake/drill_drain/foundation/DDPonderPlugin.java
@@ -1,7 +1,6 @@
 package com.cake.drill_drain.foundation;
 
 import com.cake.drill_drain.CreateDrillDrain;
-import com.simibubi.create.foundation.ponder.PonderWorldBlockEntityFix;
 import net.createmod.ponder.api.level.PonderLevel;
 import net.createmod.ponder.api.registration.*;
 import net.minecraft.resources.ResourceLocation;
@@ -17,10 +16,4 @@ public class DDPonderPlugin implements PonderPlugin {
     public void registerScenes(PonderSceneRegistrationHelper<ResourceLocation> helper) {
         DDPonderScenes.register(helper);
     }
-
-    @Override
-    public void onPonderLevelRestore(PonderLevel ponderLevel) {
-        PonderWorldBlockEntityFix.fixControllerBlockEntities(ponderLevel);
-    }
-
 }


### PR DESCRIPTION
`DDPonderPlugin#onPonderLevelRestore` calls `PonderWorldBlockEntityFix#fixControllerBlockEntities`, which causes controller BE position being adjusted twice. Because `PonderWorldBlockEntityFix#fixControllerBlockEntities` is applied globally instead of seperately and already been called by `CreatePonderPlugin`.

https://github.com/DragonsPlusMinecraft/CreateEnchantmentIndustry/issues/342#issuecomment-3522527164
